### PR TITLE
Update module github.com/google/go-github to v89 and adapt NewClient API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.5
 require (
 	github.com/gofri/go-github-pagination v1.0.1
 	github.com/gofri/go-github-ratelimit/v2 v2.0.2
-	github.com/google/go-github/v86 v86.0.0
+	github.com/google/go-github/v89 v89.0.0
 	github.com/m-mizutani/goerr/v2 v2.0.1
 	golang.org/x/sync v0.22.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -5,8 +5,8 @@ github.com/gofri/go-github-ratelimit/v2 v2.0.2/go.mod h1:YBQt4gTbdcbMjJFT05YFEaE
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
-github.com/google/go-github/v86 v86.0.0 h1:S/6aANJhwRm8EQmGKVML3j41yq0h2BsTP8FnDkO7kcA=
-github.com/google/go-github/v86 v86.0.0/go.mod h1:zKv1l4SwDXNFMGByi2FWkq71KwSXqj/eQRZuqtmcot8=
+github.com/google/go-github/v89 v89.0.0 h1:35bEK5XoEcF3PZrlVbl9XN63f5BcJRA/UGkxeC9xPg0=
+github.com/google/go-github/v89 v89.0.0/go.mod h1:QLcbU0ipeAqQuR5KSg8c2lql4Qk1EwJ2dWz/0rP4Nho=
 github.com/google/go-querystring v1.2.0 h1:yhqkPbu2/OH+V9BfpCVPZkNmUXhb2gBxJArfhIxNtP0=
 github.com/google/go-querystring v1.2.0/go.mod h1:8IFJqpSRITyJ8QhQ13bmbeMBDfmeEJZD5A0egEOmkqU=
 github.com/m-mizutani/goerr/v2 v2.0.1 h1:Z0XZiliOcCw/qoPR8dEle0xMQw781UmvlySbDHErU2U=

--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ import (
 	"github.com/gofri/go-github-ratelimit/v2/github_ratelimit"
 	"github.com/gofri/go-github-ratelimit/v2/github_ratelimit/github_primary_ratelimit"
 	"github.com/gofri/go-github-ratelimit/v2/github_ratelimit/github_secondary_ratelimit"
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v89/github"
 	"github.com/m-mizutani/goerr/v2"
 	"golang.org/x/sync/errgroup"
 	"gopkg.in/yaml.v3"

--- a/main.go
+++ b/main.go
@@ -210,7 +210,14 @@ func main() {
 		githubpagination.WithPerPage(100),
 	)
 
-	client := github.NewClient(paginator).WithAuthToken(token)
+	client, err := github.NewClient(
+		github.WithHTTPClient(paginator),
+		github.WithAuthToken(token),
+	)
+	if err != nil {
+		slog.Error("failed create github client", slog.Any("error", err))
+		os.Exit(1)
+	}
 
 	username, err := canonicalUsername(ctx, client, rawUsername)
 	if err != nil {


### PR DESCRIPTION
## Overview

Updates `github.com/google/go-github` from **v86 → v89** and adapts `main.go` for the breaking API change introduced in v87.

Renovate's #867 performs the same dependency bump but lacks the accompanying code change, so its CI (`golangci-lint` typecheck) fails. Renovate also force-overwrites its branch, which repeatedly wipes any fix commit pushed there. This PR bundles the dependency bump and the code fix on a standalone branch to resolve both problems.

## Root cause

go-github **v87** introduced a breaking change ([google/go-github#4201] "Refactor client constructor to use options pattern") that changed the `NewClient` signature:

- Old (v86): `func NewClient(httpClient *http.Client) *Client`
- New (v87+): `func NewClient(opts ...ClientOptionsFunc) (*Client, error)`

`main.go:213` still used the old API, producing these compile errors:

```
./main.go:213: multiple-value github.NewClient(paginator) (value of type (*github.Client, error)) in single-value context
./main.go:213: cannot use paginator (*http.Client) as github.ClientOptionsFunc value
```

## Changes

- `go.mod` / `go.sum`: bump go-github to v89.0.0 (same as Renovate #867)
- `main.go`:
  - update import to `go-github/v89`
  - switch client construction to the new options pattern

```go
client, err := github.NewClient(
	github.WithHTTPClient(paginator),
	github.WithAuthToken(token),
)
if err != nil {
	slog.Error("failed create github client", slog.Any("error", err))
	os.Exit(1)
}
```

The `WithAuthToken` transport wraps the existing transport of the client passed via `WithHTTPClient`, so the original pagination / rate-limit + auth composition is preserved (verified against the go-github v89 source).

## Verification

- `go build ./...` passes
- `go vet ./...` passes
- CI (Taskfile `default`, which runs `golangci-lint run ./...`) is green

## Related

- Supersedes #867 (once merged, Renovate should auto-close #867 since the dependency is already up to date).