### PR TITLE
Sign automated commits with ghcommit (Verified)

### DIFF
--- a/.aqua.yaml
+++ b/.aqua.yaml
@@ -13,6 +13,7 @@ packages:
 - name: suzuki-shunsuke/pinact@v4.1.0
 - name: google/yamlfmt@v0.21.0
 - name: k1LoW/octocov@v0.75.10
+- name: planetscale/ghcommit@v0.1.78
 - name: koalaman/shellcheck@v0.11.0
 - name: mvdan/sh@v3.13.1
 - name: securego/gosec@v2.28.0

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -41,15 +41,6 @@ jobs:
         app-id: ${{ secrets.APP_ID }}
         private-key: ${{ secrets.PRIVATE_KEY }}
         permission-contents: write
-    - name: Commit and Push
-      if: github.ref == 'refs/heads/main'
-      run: |-
-        git config --global user.name "github-actions"
-        git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
-        git remote set-url origin "https://x-access-token:${APP_TOKEN}@github.com/${{ github.repository }}"
-        git commit -am "Update datastores" && git push || exit 0
-      env:
-        APP_TOKEN: ${{ steps.app-token.outputs.token }}
     - name: Central Coverage Report (octocov)
       if: github.ref == 'refs/heads/main'
       uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -59,3 +50,23 @@ jobs:
           await exec.exec(`${toolpath}`)
       env:
         OCTOCOV_GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+    - name: Commit changes (verified)
+      if: github.ref == 'refs/heads/main'
+      run: |
+        set -euo pipefail
+        args=()
+        while IFS= read -r -d '' line; do
+          path="${line:3}"
+          if [[ "${line:0:2}" == *D* ]]; then
+            args+=(--delete "${path}")
+          else
+            args+=(--add "${path}")
+          fi
+        done < <(git status -z --porcelain=v1 --no-renames --untracked-files=all -- .octocov.yml README.md badges)
+        if [ "${#args[@]}" -eq 0 ]; then
+          echo "No changes to commit"
+          exit 0
+        fi
+        ghcommit --repository "${GITHUB_REPOSITORY}" --branch "${GITHUB_REF_NAME}" --message "Update by octocov" "${args[@]}"
+      env:
+        GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.octocov.yml
+++ b/.octocov.yml
@@ -4,7 +4,7 @@ central:
     datastores:
     - local://badges
   push:
-    enable: true
+    enable: false
   reports:
     datastores:
     - artifact://takumin/boilerplate-golang-cli

--- a/.octocov.yml
+++ b/.octocov.yml
@@ -4,7 +4,7 @@ central:
     datastores:
     - local://badges
   push:
-    enable: false
+    enable: true
   reports:
     datastores:
     - artifact://takumin/boilerplate-golang-cli


### PR DESCRIPTION
## Purpose

Make the automated commits created by CI show as **Verified** on GitHub.

Previously CI produced two automated commits:

1. **Update datastores** — a raw `git commit -am ... && git push` (GitHub App token embedded in the remote URL) pushing `.octocov.yml`.
2. **Update by octocov** — octocov's own `central.push.enable: true`, pushing `README.md` / `badges/**`.

Both were plain git pushes, so they appeared as **Unverified**.

[planetscale/ghcommit](https://github.com/planetscale/ghcommit) creates commits through GitHub's GraphQL `createCommitOnBranch` API, which are signed with GitHub's web-flow GPG key and therefore show as **Verified**. This PR routes the automated commit through ghcommit and consolidates it into a single Verified commit.

## Changes

- **`.aqua.yaml`**: add `planetscale/ghcommit@v0.1.78` so the CLI is available in CI (installed like every other tool via `aqua install --all`).
- **`.octocov.yml`**: set `central.push.enable` from `true` to `false`. Disabling push does not stop generation — octocov still writes `README.md` / `badges/**` locally; it just no longer pushes them itself.
- **`.github/workflows/integration.yml`**:
  - Remove the `Commit and Push` step that used a raw `git commit` / `git push`.
  - After the octocov step, add a `Commit changes (verified)` step that builds the `--add` / `--delete` argument list from `git status -z --porcelain=v1 --no-renames --untracked-files=all` and commits `.octocov.yml`, `README.md` and `badges` in a single `ghcommit` invocation.
  - `GITHUB_TOKEN` is still the GitHub App token, preserving the author (App bot) and the downstream-trigger behavior.

## Design notes

- The ghcommit CLI does not support globs, directories, or auto-detecting changed files, so the changed paths are enumerated explicitly from `git status`.
- `--no-renames` decomposes renames into delete+add, and `--untracked-files=all` expands newly added badges into individual file entries.
- When there are no changes the step exits 0 as a no-op (equivalent to the previous `... || exit 0`), so scheduled runs with no diff do not fail.
- The commit steps are gated on `if: github.ref == 'refs/heads/main'`, so the actual Verified commit is produced only after merge to `main` (or via `workflow_dispatch` / schedule on the default branch).

## Verification

Ran the same linters CI uses, all green:

- `actionlint -shellcheck shellcheck` (shellcheck 0.11.0) — pass
- `ghalint run` / `ghalint act` — pass
- `yamlfmt -lint` — pass
- `editorconfig-checker` — pass

After merge, confirm that the `Update by octocov` commit contains the `.octocov.yml` / README / badges changes and shows the Verified badge on GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BL7vP4mbF1DdWSLZFvpTvP