### PR TITLE
ci: remove no-op central.push.enable from octocov config

### DIFF
--- a/.octocov.yml
+++ b/.octocov.yml
@@ -3,8 +3,6 @@ central:
   badges:
     datastores:
     - local://badges
-  push:
-    enable: true
   reports:
     datastores:
     - artifact://takumin/boilerplate-golang-cli


### PR DESCRIPTION
## Summary
- Remove the `central.push.enable: true` key from `.octocov.yml`
- octocov v0.75.10's `Push` struct only defines `If`/`Message`; there is no `enable` field, so this key was silently ignored and had no effect
- octocov only skips its built-in `git push` when `central.push` is entirely absent (nil), which was causing every CI run to create two separate "Update by octocov" commits: one pushed directly by octocov as `github-actions[bot]` (Unverified), and one made afterward by the `ghcommit` step as `takumin-app-octocov-central[bot]` (Verified)
- With the section removed, octocov generates README.md/badges locally but no longer pushes them itself; the existing "Commit changes (verified)" workflow step already picks up `.octocov.yml`/`README.md`/`badges` diffs and commits them together, collapsing history back to a single Verified commit per run

## Test plan
- [ ] Merge and observe the next scheduled/`push` CI run on `main` produces exactly one "Update by octocov" commit (Verified, `takumin-app-octocov-central[bot]`) instead of two

🤖 Generated with [Claude Code](https://claude.com/claude-code)